### PR TITLE
Fix top dir

### DIFF
--- a/lib/local_hexdocs_helpers.ex
+++ b/lib/local_hexdocs_helpers.ex
@@ -16,7 +16,7 @@ defmodule LocalHexdocs.Helpers do
       "./test/" |> Path.expand()
     else
       # script is executing normally
-      "~/" |> Path.expand()
+      "./" |> Path.expand()
     end
   end
 


### PR DESCRIPTION
I somehow made `top_dir()` `~/` when it should have been `./`.

Fixing this makes `local_hexdocs` use the default packages file if there is no `/packages` directory.

I failed to notice that I had broken this because I had created a `/packages` directory and wasn't using the default file.