### PR TITLE
Update downloaded packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,8 +339,27 @@ Updating your local Hexdocs documentation is as simple as re-running:
 ```
 mix local_docs get
 ```
+OR
+```
+mix local_docs get_then_clean   # to fetch the lastest documentation, then delete all outdated documentation
+```
 
-Each time you run this, `LocalHexdocs` will pull the latest version of documentation for each specified package.
+Each time you run this, `LocalHexdocs` will pull the latest version of documentation for each specified package and for any downloaded documentation that's not at its most recent version.
+
+Fetching the newest version of any already downloaded Hexdocs package -- regardless of whether the package is listed in a `LocalHexdocs` package list -- ensures that all your downloaded documentation remains up to date.
+
+To avoid filling your disk with outdated documentation, I recommend running either:
+```
+mix local_docs get_then_clean
+```
+to automatically delete all outdated documentation after fetching the latest... OR...
+```
+mix local_docs to_clean  # to see which documentation is considered outdated
+
+                         # THEN...
+
+mix local_docs clean     # to delete all stale documentation
+```
 
 ## Automate the periodic running of local_hexdocs
 
@@ -373,7 +392,6 @@ And, if things go well, you can see exactly what your script did:
 
 ## Known issues & possible future features
 
-* Always fetch the newest version of any already downloaded Hexdocs package (regardless of whether the package is listed in a list of packages). This is useful for those relying on `popular_packages.ex` because packages will get added to and removed from that list over time.
 * Better handle versions with non-numeric version numbers (violating semantic versioning).
   * For now, I'm ignoring them when deciding which versions are redundant.
   * I need to add a test.

--- a/README.md
+++ b/README.md
@@ -344,9 +344,9 @@ OR
 mix local_docs get_then_clean   # to fetch the lastest documentation, then delete all outdated documentation
 ```
 
-Each time you run this, `LocalHexdocs` will pull the latest version of documentation for each specified package and for any downloaded documentation that's not at its most recent version.
+Each time you run this, `LocalHexdocs` will pull the latest version of documentation for each specified package AND any downloaded Hexdocs not at its most recent version.
 
-Fetching the newest version of any already downloaded Hexdocs package -- regardless of whether the package is listed in a `LocalHexdocs` package list -- ensures that all your downloaded documentation remains up to date.
+Fetching the newest package version of any already downloaded Hexdocs -- regardless of whether the package is listed in a `LocalHexdocs` package list -- ensures that all your downloaded Hexdocs remain up to date.
 
 To avoid filling your disk with outdated documentation, I recommend running either:
 ```
@@ -354,7 +354,7 @@ mix local_docs get_then_clean
 ```
 to automatically delete all outdated documentation after fetching the latest... OR...
 ```
-mix local_docs to_clean  # to see which documentation is considered outdated
+mix local_docs to_clean  # to see which packages' documentation is outdated
 
                          # THEN...
 

--- a/lib/local_hexdocs.ex
+++ b/lib/local_hexdocs.ex
@@ -39,10 +39,8 @@ defmodule LocalHexdocs do
 
   Called by `local_docs.exs list`
   """
-  def downloaded_packages do
-    hexpm_dir()
-    |> File.ls!()
-    |> Enum.sort()
+  def display_downloaded_packages do
+    downloaded_packages()
     |> IO.inspect(
       label: "Packages downloaded in #{hexpm_dir()}",
       limit: :infinity,
@@ -167,6 +165,12 @@ defmodule LocalHexdocs do
       {:error, _err} ->
         packages_file_as_list()
     end
+  end
+
+  defp downloaded_packages do
+    hexpm_dir()
+    |> File.ls!()
+    |> Enum.sort()
   end
 
   defp package_name_plus_versions(name) do

--- a/lib/local_hexdocs.ex
+++ b/lib/local_hexdocs.ex
@@ -276,13 +276,20 @@ defmodule LocalHexdocs do
   end
 
   defp desired_packages do
-    packages_files()
-    |> Enum.flat_map(&extract_package_names/1)
+    # Explicitly requested packages + already downloaded packages
+    (requested_packages() ++ downloaded_packages())
     |> Enum.sort()
     |> Enum.uniq()
 
     # For testing:
     # |> Enum.take(10)
+  end
+
+  defp requested_packages do
+    packages_files()
+    |> Enum.flat_map(&extract_package_names/1)
+    |> Enum.sort()
+    |> Enum.uniq()
   end
 
   defp extract_package_names(filepath) do

--- a/lib/local_hexdocs.ex
+++ b/lib/local_hexdocs.ex
@@ -167,7 +167,7 @@ defmodule LocalHexdocs do
     end
   end
 
-  defp downloaded_packages do
+  def downloaded_packages do
     hexpm_dir()
     |> File.ls!()
     |> Enum.sort()

--- a/lib/mix/tasks/local_docs.ex
+++ b/lib/mix/tasks/local_docs.ex
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.LocalDocs do
         LocalHexdocs.remove_stale_versions()
 
       ["list"] ->
-        LocalHexdocs.downloaded_packages()
+        LocalHexdocs.display_downloaded_packages()
 
       ["versions"] ->
         LocalHexdocs.display_downloaded_packages_with_versions()

--- a/test/default_packages.txt
+++ b/test/default_packages.txt
@@ -1,3 +1,0 @@
-ecto_psql_extras
-ecto_sql
-ecto_sqlite3


### PR DESCRIPTION
This change ensures that `mix local_docs get` updates all downloaded Hexdocs packages that have gotten out of date, whether or not they're explicitly listed in a `LocalHexdocs` package configuration file.