### PR TITLE
explicitly call hex.docs fetch --latest

### DIFF
--- a/lib/local_hexdocs.ex
+++ b/lib/local_hexdocs.ex
@@ -59,7 +59,7 @@ defmodule LocalHexdocs do
     stream =
       desired_packages()
       |> Task.async_stream(
-        fn lib -> :os.cmd(~c(HEX_HOME=#{@hex_home} #{@mix_path} hex.docs fetch #{lib})) end,
+        fn lib -> :os.cmd(~c(HEX_HOME=#{@hex_home} #{@mix_path} hex.docs fetch --latest #{lib})) end,
         timeout: @timeout_ms,
         max_concurrency: @max_concurrency
       )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LocalHexdocs.MixProject do
   def project do
     [
       app: :local_hexdocs,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
(...but it's still not pulling down the latest elixir package)

When I built this library, I watched the script pull updated versions of outdated docs from Hexdocs.pm.

I noticed tonight that the script was NOT updating the Elixir docs. Locally, I had 1.17.3 and was not getting 1.18.4. (I didn't check any other libraries.)

According to https://hexdocs.pm/hex/Mix.Tasks.Hex.Docs.html, the `mix hex.docs fetch PACKAGE [VERSION]` call should include `--latest - Looks for the latest release of a package` if you want the latest release.

So I have added that, but I'm still not getting a more updated package doc version from Hexdocs.pm. I could well be doing something wrong, but the script was previously updating docs packages, so it's possible there's a Hexdocs.pm bug.

I am able to pull the more recent package version if I request a specific version:
`...:~/Git/local_hexdocs$ HEX_HOME=~/.hex mix hex.docs fetch --latest elixir 1.18.4
Docs fetched: .../.hex/docs/hexpm/elixir/1.18.4`

:thinking: 